### PR TITLE
[FEAT] Add Brew Formula and MIT License

### DIFF
--- a/Formula/lino.rb
+++ b/Formula/lino.rb
@@ -1,0 +1,22 @@
+class Lino < Formula
+  desc "ETL tool to manage test data (Large Input Narrow Output)"
+  homepage "https://github.com/CGI-FR/LINO"
+  version "3.3.0"
+  license "GPL-3.0"
+
+  url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_darwin_amd64.tar.gz"
+  sha256 "04d1f7515d8e754f2614faef63cb289b9a3107140df52284ae79d0fb18e41351"
+
+  def install
+
+    chmod "+x", "lino"
+    bin.install "lino"
+
+    generate_completions_from_executable(bin/"lino", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lino --version")
+    assert_match "Usage:", shell_output("#{bin}/lino --help")
+  end
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2025 [gambhirsharma](https://github.com/gambhirsharma)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Description:

This PR makes it easier to install Lino on macOS by adding a Homebrew formula. It installs Lino version `3.3.0`, includes command-line autocompletion for a better user experience, and adds the MIT License to the project for open-source clarity.

## How does it work? 
The Homebrew formula first downloads the macOS binary for Lino version `3.3.0`. It then makes the binary executable and adds it to your system's PATH. After this, CLI autocompletion is set up, and finally, test cases are run to ensure everything is working perfectly.

## checklist: 
- [x] Homebrew formula created and tested locally.
- [x] MIT License file added with correct information.

---
**NOTE** @adrienaury 

Before integrating these changes, it's absolutely crucial that the Homebrew tap repository is renamed from `lino-homebrew` to `homebrew-lino`.

I've tested this thoroughly, and I can confirm that the installation will not function otherwise. This renaming aligns with Homebrew's required conventions, detailed here: [Repository naming conventions](https://docs.brew.sh/Taps#:~:text=Repository%20naming%20conventions%20and%20assumptions,give%20the%20full%20URL%20explicitly.)