### PR TITLE
[FEAT]: Add Linux support for `lino`

### DIFF
--- a/Formula/lino.rb
+++ b/Formula/lino.rb
@@ -4,8 +4,20 @@ class Lino < Formula
   version "3.3.0"
   license "GPL-3.0"
 
-  url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_darwin_amd64.tar.gz"
-  sha256 "04d1f7515d8e754f2614faef63cb289b9a3107140df52284ae79d0fb18e41351"
+  if OS.mac?
+    url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_darwin_amd64.tar.gz"
+    sha256 "04d1f7515d8e754f2614faef63cb289b9a3107140df52284ae79d0fb18e41351"
+  elsif OS.linux? 
+    if Hardware::CPU.intel?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_linux_amd64.tar.gz"
+        sha256 "3939db3e66219b0a1e002abf822443fed6261e67c1b0d031112d2db8009ef856"
+      else
+        url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_linux_386.tar.gz"
+        sha256 "e1b37706c8fffa51b663257012b7d9a123272a19beffe39dfb2911528a2bf066"
+      end
+    end
+  end
 
   def install
 

--- a/Formula/lino.rb
+++ b/Formula/lino.rb
@@ -8,15 +8,8 @@ class Lino < Formula
     url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_darwin_amd64.tar.gz"
     sha256 "04d1f7515d8e754f2614faef63cb289b9a3107140df52284ae79d0fb18e41351"
   elsif OS.linux? 
-    if Hardware::CPU.intel?
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_linux_amd64.tar.gz"
-        sha256 "3939db3e66219b0a1e002abf822443fed6261e67c1b0d031112d2db8009ef856"
-      else
-        url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_linux_386.tar.gz"
-        sha256 "e1b37706c8fffa51b663257012b7d9a123272a19beffe39dfb2911528a2bf066"
-      end
-    end
+    url "https://github.com/CGI-FR/LINO/releases/download/v#{version}/LINO_#{version}_linux_amd64.tar.gz"
+    sha256 "3939db3e66219b0a1e002abf822443fed6261e67c1b0d031112d2db8009ef856"
   end
 
   def install


### PR DESCRIPTION
This PR enables full Linux compatibility for the `lino` formula.

Previously macOS-only, users can now install and use `lino` via
Homebrew on Linux environments.

Successfully tested on `Ubuntu 24.04.2 LTS (x86_64)`.

**Note**: This formula will not work on 32-bit Linux architectures due
to a limitation of Homebrew on Linux.

